### PR TITLE
Add translations

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -24,11 +24,12 @@ export default defineConfig({
       {
         text: 'Content',
         items: [
-          { text: 'Introduction', link: '/01-content/01-introduction',
+          {
+            text: 'Introduction', link: '/01-content/01-introduction',
             items: [
               { text: 'Urls', link: '/01-content/02-urls' },
             ]
-           },
+          },
           { text: 'Types', link: '/02-types/01-introduction' },
           { text: 'Fields', link: '/03-fields/01-introduction' },
           { text: 'Blocks', link: '/04-blocks/01-introduction' },
@@ -50,12 +51,15 @@ export default defineConfig({
       {
         text: 'Extending Backstage',
         items: [
-          { text: 'Plugins', link: '/09-plugins/01-introduction', items: [
-            { text: 'Translations', link: '/09-plugins/plugins/translations/01-introduction', items: [
-              { text: 'Laravel Translations', link: '/09-plugins/plugins/translations/sub/laravel-translations/01-introduction' },
+          {
+            text: 'Plugins', link: '/09-plugins/01-introduction', items: [
+              {
+                text: 'Translations', link: '/09-plugins/plugins/translations/01-introduction', items: [
+                  { text: 'Laravel Translations', link: '/09-plugins/plugins/translations/sub/laravel-translations/01-introduction' },
+                ]
+              },
             ]
-            },
-          ] }
+          }
         ]
       }
     ],

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -50,7 +50,12 @@ export default defineConfig({
       {
         text: 'Extending Backstage',
         items: [
-          { text: 'Plugins', link: '/09-plugins/01-introduction' }
+          { text: 'Plugins', link: '/09-plugins/01-introduction', items: [
+            { text: 'Translations', link: '/09-plugins/plugins/translations/01-introduction', items: [
+              { text: 'Laravel Translations', link: '/09-plugins/plugins/translations/sub/laravel-translations/01-introduction' },
+            ]
+            },
+          ] }
         ]
       }
     ],

--- a/09-plugins/01-introduction.md
+++ b/09-plugins/01-introduction.md
@@ -10,4 +10,4 @@ To help you get started quickly, we provide a set of plugins and packages that w
 
 -   [Media Field](https://github.com/backstagephp/media-field)
 -   [Uploadcare Field](https://github.com/backstagephp/uploadcare-field)
--   [Translations](https://github.com/backstagephp/translations)
+-   [Translations](/09-plugins/plugins/translations/01-introduction.html)

--- a/09-plugins/01-introduction.md
+++ b/09-plugins/01-introduction.md
@@ -10,3 +10,4 @@ To help you get started quickly, we provide a set of plugins and packages that w
 
 -   [Media Field](https://github.com/backstagephp/media-field)
 -   [Uploadcare Field](https://github.com/backstagephp/uploadcare-field)
+-   [Translations](https://github.com/backstagephp/translations)

--- a/09-plugins/plugins/translations/01-introduction.md
+++ b/09-plugins/plugins/translations/01-introduction.md
@@ -1,0 +1,72 @@
+---
+title: Backstage Translations
+---
+
+# Translations for Filament
+
+## Before using
+
+Please read this documentation first: [Laravel Translations docs](/09-plugins/plugins/translations/sub/laravel-translations/01-introduction.html)
+
+## Installation
+
+You can install the package via composer:
+
+```bash
+composer require backstage/translations
+```
+
+You can publish and run the migrations with:
+
+```bash
+php artisan vendor:publish --provider="Backstage\Translations\Laravel\TranslationServiceProvider"
+php artisan vendor:publish --provider="Backstage\Translations\Filament\TranslationServiceProvider"
+php artisan migrate
+```
+
+You can publish the config file with:
+
+```bash
+php artisan vendor:publish --tag="translations-config"
+php artisan vendor:publish --tag="backstage-translations-config"
+```
+
+Optionally, you can publish the views using
+
+```bash
+php artisan vendor:publish --tag="backstage-translations-views"
+```
+
+Add the TranslationsPlugin to the desired panel provider:
+
+```php
+use Backstage\Translations\Filament\TranslationsPlugin;
+
+$panel
+    ->plugins([
+        TranslationsPlugin::make(),
+    ]);
+```
+
+Optionally, you can disable the language switcher and rely on the ``default`` language:
+ ```php
+use Backstage\Translations\Filament\TranslationsPlugin;
+
+$panel
+    ->plugins([
+        TranslationsPlugin::make()
+            ->languageSwitcherDisabled(),
+    ]);
+```
+
+If you want to show only the language switcher in a panel, you can set the `canManageTranslations` to `false`:
+
+ ```php
+use Backstage\Translations\Filament\TranslationsPlugin;
+
+$panel
+    ->plugins([
+        TranslationsPlugin::make()
+            ->userCanManageTranslations(false),
+    ]);
+```

--- a/09-plugins/plugins/translations/sub/laravel-translations/01-introduction.md
+++ b/09-plugins/plugins/translations/sub/laravel-translations/01-introduction.md
@@ -1,0 +1,123 @@
+---
+title: Backstage Laravel Translations
+---
+
+# Translations for Laravel
+
+## Installation
+
+You can install the package via composer:
+
+```bash
+composer require backstage/laravel-translations
+```
+
+You can publish and run the migrations with:
+
+```bash
+php artisan vendor:publish --provider="Backstage\Translations\Laravel\TranslationServiceProvider"
+php artisan migrate
+```
+
+This is the contents of the published config file:
+
+```php
+use EchoLabs\Prism\Enums\Provider;
+
+[
+    'scan' => [
+        'paths' => [
+            base_path(),
+        ],
+        'files' => [
+            '*.php',
+            '*.blade.php',
+            '*.json',
+        ],
+
+        'functions' => [
+            'trans',
+            'trans_choice',
+            'Lang::transChoice',
+            'Lang::trans',
+            'Lang::get',
+            'Lang::choice',
+            '@lang',
+            '@choice',
+            '__',
+        ],
+    ],
+
+    'translators' => [
+        'default' => env('TRANSLATION_DRIVER', 'google-translate'),
+
+        'drivers' => [
+            'google-translate' => [
+                // no options
+            ],
+
+            'ai' => [
+                'provider' => Provider::OpenAI, // Example provider
+                'model' => 'text-davinci-003', // Example model
+                'system_prompt' => 'You are an expert mathematician who explains concepts simply. The only thing you do it output what i ask. No comments, no extra information. Just the answer.', // Example system prompt
+            ],
+        ],
+    ],
+];
+
+```
+
+If you have choosen the AI driver, please read the [Prism documentation](https://prism.echolabs.dev/providers/anthropic.html) on how to configure providers.
+
+## Usage
+
+### Add lang types
+
+If you want to add a language use the following command:
+
+```bash
+php artisan translations:languages:add {locale} {label}
+```
+
+For example:
+
+```bash
+php artisan translations:languages:add nl Nederlands
+
+translations:languages:add en English
+
+translations:languages:add fr-BE Français // French specifically for Belgians
+```
+
+The command can also be used without in-command-line parameters
+
+### Scan for translations
+
+To scan for translations within your Laravel application, use the following command:
+
+```bash
+php artisan translations:scan
+```
+
+### Translate scanned translations
+
+To translate the scanned translations, use the following command:
+
+```bash
+php artisan translations:translate
+        {--all : Translate language strings for all languages}
+        {--code= : Translate language strings for a specific language}
+        {--update : Update and overwrite existing translations}
+```
+
+For example:
+
+```bash
+php artisan translations:translate --code=nl
+
+php artisan translations:translate --code=en
+
+php artisan translations:translate --code=fr-BE --update // overwrite existing translations
+
+php artisan translations:translate // translate all languages
+```


### PR DESCRIPTION
This pull request introduces a new "Translations" plugin for Backstage, including its integration into the documentation and detailed setup instructions for both Filament and Laravel. The changes primarily focus on adding support for managing translations, alongside updates to the navigation structure and plugin documentation.

### Navigation Updates
* Updated `.vitepress/config.mts` to include nested navigation items for the new "Translations" plugin under the "Extending Backstage" section. This includes links to both the main Translations page and its Laravel-specific subpage. [[1]](diffhunk://#diff-ab65a82c842000e20a42096f9c6a4bfaa1856e905da5e37f0dc102922c93deb4L27-R28) [[2]](diffhunk://#diff-ab65a82c842000e20a42096f9c6a4bfaa1856e905da5e37f0dc102922c93deb4L53-R62)

### Plugin Documentation
* Added a new file `09-plugins/plugins/translations/01-introduction.md` documenting the setup and usage of the "Translations" plugin for Filament, including installation steps, configuration options, and example code snippets.
* Added a subpage `09-plugins/plugins/translations/sub/laravel-translations/01-introduction.md` detailing the Laravel-specific implementation of the "Translations" plugin, including installation, configuration, and usage instructions for scanning and translating language strings.

### Plugin References
* Updated `09-plugins/01-introduction.md` to include a link to the GitHub repository for the "Translations" plugin.